### PR TITLE
rename package to fix go get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module postwoman.io/proxy
+module github.com/hoppscotch/proxyscotch
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -5,10 +5,10 @@ import (
 	"github.com/getlantern/systray"
 	"github.com/pkg/browser"
 
-	icon "postwoman.io/proxy/icons"
-	"postwoman.io/proxy/inputbox"
-	"postwoman.io/proxy/libproxy"
-	"postwoman.io/proxy/notifier"
+	icon "github.com/hoppscotch/proxyscotch/icons"
+	"github.com/hoppscotch/proxyscotch/inputbox"
+	"github.com/hoppscotch/proxyscotch/libproxy"
+	"github.com/hoppscotch/proxyscotch/notifier"
 )
 
 var (

--- a/server/server.go
+++ b/server/server.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"log"
 
-	"postwoman.io/proxy/libproxy"
+	"github.com/hoppscotch/proxyscotch/libproxy"
 )
 
 func main() {


### PR DESCRIPTION
To preface this, I am not familiar with Go packaging other than `go get` often being used to grab and build packages in a standard way. It seems like the current packaging uses a name for the package that is both from before the name change and cannot be used to fetch the source. I'm not sure if this is common practice in go. However, I have changed it to match the GitHub URL so `go get` will work correctly.

Here's the previous error, which as far as I can tell, this fixes:

```
~ » go get github.com/hoppscotch/proxyscotch
package postwoman.io/proxy/icons: unrecognized import path "postwoman.io/proxy/icons": parse https://postwoman.io/proxy/icons?go-get=1: no go-import meta tags ()
package postwoman.io/proxy/inputbox: unrecognized import path "postwoman.io/proxy/inputbox": parse https://postwoman.io/proxy/inputbox?go-get=1: no go-import meta tags ()
package postwoman.io/proxy/libproxy: unrecognized import path "postwoman.io/proxy/libproxy": parse https://postwoman.io/proxy/libproxy?go-get=1: no go-import meta tags ()
package postwoman.io/proxy/notifier: unrecognized import path "postwoman.io/proxy/notifier": parse https://postwoman.io/proxy/notifier?go-get=1: no go-import meta tags ()
```