### PR TITLE
Slightly improve Linux support for the desktop app

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hoppscotch/proxyscotch
 go 1.18
 
 require (
+	github.com/adrg/xdg v0.4.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/deckarep/gosx-notifier v0.0.0-20180201035817-e127226297fb
 	github.com/gen2brain/dlgs v0.0.0-20211108104213-bade24837f0b

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -150,6 +152,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -3,13 +3,21 @@ package notifier
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/adrg/xdg"
 )
 
 func GetIcon() string {
-	return GetIconPath() + "/icon.png"
-}
-
-func GetIconPath() string {
+	// Backward compatibility: use the legacy icons dir if it contains
+	// icon.png
 	dir, _ := filepath.Abs(filepath.Dir(os.Args[0]))
-	return dir + "/icons"
+	legacyFile := filepath.Join(dir, "icons", "icon.png")
+	if _, err := os.Stat(legacyFile); err == nil {
+		return legacyFile
+	}
+
+	// Otherwise, use the file from a standard location, or return an empty
+	// string if not found.
+	path, _ := xdg.SearchDataFile("proxyscotch/icon.png")
+	return path
 }

--- a/notifier/notifier_linux.go
+++ b/notifier/notifier_linux.go
@@ -1,5 +1,16 @@
 package notifier
 
+import (
+	"os/exec"
+)
+
 func Notify(appName, title, message, icon string) error {
-	return nil
+	cmd := exec.Command(
+		"notify-send",
+		"--app-name", appName,
+		"--icon", icon,
+		title,
+		message,
+	)
+	return cmd.Run()
 }


### PR DESCRIPTION
For context: I started writing an Arch Linux package for proxyscotch, but quickly hit a roadblock: if `proxyscotch-desktop` is installed in `/usr/bin`, then at runtime it tries to creates its certificates in `/usr/bin/data`, which is obviously wrong.

So, I looked into doing what I wanted: install the binary and icon system-wide, but use the user's home directory to store app data (certificates).

In the end, I changed the following things:
- Use the XDG data home for certificates storage, with fallback to the previous behavior if certificates already exists. This means that new install will by default use `~/.local/share/proxyscotch/cert.pem` (Linux) or `~/Library/Application Support/proxyscotch/cert.pem` (macOS) or `LocalAppData\proxyscotch\proxy.pem` (Windows)
- Similarly, the app icon is looked up in the previous location for backward compatibility, then in `/usr/local/share/proxyscotch` and `/usr/share/proxyscotch` (Linux), `/Library/Application Support/proxyscotch` (macOS), `RoamingAppData\proxyscotch` and `ProgramData\proxyscotch` (Windows)
- Implement a basic Linux notifier by simply calling the `notify-send` command (much simpler than adding a library that implements DBus notifications...)

I believe all these changes should be backward-compatible. Please let me know of any issue, or if you would prefer me to split this into several smaller PRs.

