### PR TITLE
feat: add support for custom hoppscotch url

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The server binary supports various options to customize your instance. Each of t
 
 - `host` (default: `localhost:9159`) -- the hostname the server should listen on.
 - `token` (default: `<blank>`) -- the proxy Access Token used to restrict access to the server (feature disabled if left blank).
+- `base-url` (default: `https://hoppscotch.io/`) -- the url of the hoppscotch instance (if the request origin is not an allowed origin, there is a redirect to hoppscotch base-url).
 - `allowed-origins` (default: `*`) -- a comma separated list of allowed origins (for the Access-Control-Allow-... (CORS) headers) (use * to permit any)
 - `banned-outputs` (default: `<blank>`) -- a comma separated list of values to redact from responses (feature disabled if left blank).
 - `banned-dests` (default: `<blank>`) -- a comma separated list of destination hosts to prevent access to (feature disabled if left blank).
@@ -105,6 +106,7 @@ The container exposes the proxy through port `9159`.
 
 Environment Variables the container accepts:
 - `PROXYSCOTCH_TOKEN` (default: `<blank>`) -- the proxy Access Token used to restrict access to the server (feature disabled if left blank).
+- `PROXYSCOTCH_BASE_URL` (default: `https://hoppscotch.io/`) -- the url of the hoppscotch instance (if the request origin is not an allowed origin, there is a redirect to hoppscotch base-url)
 - `PROXYSCOTCH_ALLOWED_ORIGINS` (default: `*`) -- a comma separated list of allowed origins (for the Access-Control-Allow-... (CORS) headers) (use * to permit any)
 - `PROXYSCOTCH_BANNED_OUTPUTS` (default: `<blank>`) -- a comma separated list of values to redact from responses (feature disabled if left blank).
 - `PROXYSCOTCH_BANNED_DESTS` (default: `<blank>`) -- a comma separated list of destination hosts to prevent access to (feature disabled if left blank).
@@ -115,6 +117,7 @@ You can provide these values to the container as follows:
   ```sh
   docker run -d \
   -e PROXYSCOTCH_TOKEN=<token> \
+  -e PROXYSCOTCH_BASE_URL=<base_url> \
   -e PROXYSCOTCH_ALLOWED_ORIGINS=<allowed_origins> \
   -e PROXYSCOTCH_BANNED_OUTPUTS=<banned_outputs> \
   -e PROXYSCOTCH_BANNED_DESTS=<banned_dests> \
@@ -122,7 +125,7 @@ You can provide these values to the container as follows:
   hoppscotch/proxyscotch:v0.1.4
   ```
 
-- Via `docker-commpose`:
+- Via `docker-compose`:
 ```yaml
 # docker-compose.yml
 

--- a/container_run.sh
+++ b/container_run.sh
@@ -2,6 +2,7 @@
 
 # Default values
 DEFAULT_TOKEN=""
+DEFAULT_BASE_URL="https://hoppscotch.io/"
 DEFAULT_ALLOWED_ORIGINS="*"
 DEFAULT_BANNED_OUTPUTS=""
 DEFAULT_BANNED_DESTS=""
@@ -19,6 +20,14 @@ if [ -n "${PROXYSCOTCH_TOKEN}" ]; then
   TOKEN_ARG="--token=${PROXYSCOTCH_TOKEN}"
 elif [ -n "${DEFAULT_TOKEN}" ]; then
   TOKEN_ARG="--token=${DEFAULT_TOKEN}"
+fi
+
+# Process base-url of hoppscotch instance
+BASE_URL_ARG=""
+if [ -n "${PROXYSCOTCH_BASE_URL}" ]; then
+  BASE_URL_ARG="--base-url=${PROXYSCOTCH_BASE_URL}"
+else
+  BASE_URL_ARG="--base-url=${DEFAULT_BASE_URL}"
 fi
 
 # Process allowed-origins
@@ -45,4 +54,4 @@ elif [ -n "${DEFAULT_BANNED_DESTS}" ]; then
 fi
 
 # Execute the command with the arguments
-proxyscotch $HOST_ARG $TOKEN_ARG $ORIGINS_ARG $BANNED_OUTPUTS_ARG $BANNED_DESTS_ARG
+proxyscotch $HOST_ARG $TOKEN_ARG $BASE_URL_ARG $ORIGINS_ARG $BANNED_OUTPUTS_ARG $BANNED_DESTS_ARG

--- a/libproxy/proxy.go
+++ b/libproxy/proxy.go
@@ -20,6 +20,7 @@ type statusChangeFunction func(status string, isListening bool)
 
 var (
 	accessToken        string
+	baseUrl            string
 	sessionFingerprint string
 	allowedOrigins     []string
 	bannedOutputs      []string
@@ -76,6 +77,7 @@ func isAllowedOrigin(origin string) bool {
 func Initialize(
 	initialAccessToken string,
 	proxyURL string,
+	initialBaseURL string,
 	initialAllowedOrigins string,
 	initialBannedOutputs string,
 	initialBannedDests string,
@@ -93,6 +95,7 @@ func Initialize(
 	}
 	allowedOrigins = strings.Split(initialAllowedOrigins, ",")
 	accessToken = initialAccessToken
+	baseUrl = initialBaseURL
 	sessionFingerprint = uuid.New().String()
 	log.Println("Starting proxy server...")
 
@@ -163,8 +166,8 @@ func proxyHandler(response http.ResponseWriter, request *http.Request) {
 			return
 		}
 
-		// If it is not an allowed origin, redirect back to hoppscotch.io.
-		response.Header().Add("Location", "https://hoppscotch.io/")
+		// If it is not an allowed origin, redirect back to hoppscotch base-url.
+		response.Header().Add("Location", baseUrl)
 		response.WriteHeader(301)
 		return
 	} else {

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func onExit() {
 }
 
 func runHoppscotchProxy() {
-	libproxy.Initialize("hoppscotch", "127.0.0.1:9159", "https://hoppscotch.io", "", "", onProxyStateChange, true, nil)
+	libproxy.Initialize("hoppscotch", "127.0.0.1:9159", "https://hoppscotch.io/", "https://hoppscotch.io", "", "", onProxyStateChange, true, nil)
 }
 
 func onProxyStateChange(status string, isListening bool) {

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 func main() {
 	hostPtr := flag.String("host", "localhost:9159", "the hostname that the server should listen on.")
 	tokenPtr := flag.String("token", "", "the Proxy Access Token used to restrict access to the server.")
+	baseUrlPtr := flag.String("base-url", "https://hoppscotch.io/", "the url of the hoppscotch instance.")
 	allowedOriginsPtr := flag.String("allowed-origins", "*", "a comma separated list of allowed origins.")
 	bannedOutputsPtr := flag.String("banned-outputs", "", "a comma separated list of banned outputs.")
 	bannedDestsPtr := flag.String("banned-dests", "", "a comma separated list of banned proxy destinations.")
@@ -17,7 +18,7 @@ func main() {
 	flag.Parse()
 
 	finished := make(chan bool)
-	libproxy.Initialize(*tokenPtr, *hostPtr, *allowedOriginsPtr, *bannedOutputsPtr, *bannedDestsPtr, onProxyStateChangeServer, false, finished)
+	libproxy.Initialize(*tokenPtr, *hostPtr, *baseUrlPtr, *allowedOriginsPtr, *bannedOutputsPtr, *bannedDestsPtr, onProxyStateChangeServer, false, finished)
 
 	<-finished
 }


### PR DESCRIPTION
I have a project where we run a self-hosted instance of Hoppscotch with Proxyscotch.
I thought it would be a helpful feature if the URL of this instance could be passed by argument so that the user is redirected to the correct self-hosted instance and not to hoppscotch.io (e.g. if the request has an unallowed origin)