### PR TITLE
fix: desktop app use case

### DIFF
--- a/libproxy/proxy.go
+++ b/libproxy/proxy.go
@@ -407,7 +407,7 @@ func proxyHandler(response http.ResponseWriter, request *http.Request) {
 	}
 
 	origin := request.Header.Get("Origin")
-	if origin == "" || !isAllowedOrigin(origin) {
+	if !isAllowedOrigin(origin) {
 		atomic.AddUint64(&totalErrors, 1)
 		if strings.HasPrefix(request.Header.Get("Content-Type"), "application/json") {
 			response.Header().Add("Access-Control-Allow-Headers", "*")

--- a/libproxy/proxy_test.go
+++ b/libproxy/proxy_test.go
@@ -109,6 +109,20 @@ func TestWildCardOrigin(t *testing.T) {
 	assert.Equal(t, 200, result.proxyResponse.Code)
 }
 
+func TestWildCardOriginAllowsEmptyOrigin(t *testing.T) {
+	_allowedOrigins := allowedOrigins
+	allowedOrigins = []string{"*"}
+	defer func() {
+		allowedOrigins = _allowedOrigins
+	}()
+	result := getResult(Request{
+		Method: "GET",
+		Url:    testServerUrl + "/get",
+	}, "")
+	// wildcard should permit an empty origin (e.g. desktop clients)
+	assert.Equal(t, 200, result.proxyResponse.Code)
+}
+
 func TestUrlParamsInUrl(t *testing.T) {
 	resp := getResultDef(Request{
 		Method: "GET",


### PR DESCRIPTION
Fixes #104 by removing the explicit block on empty origins which is being sent by the desktop app.

Adds a test ensuring empty origins are permitted by `*`.

A built Docker image is available for use or testing: `ghcr.io/treyturner/proxyscotch:latest`
